### PR TITLE
Blue sky directive documentation

### DIFF
--- a/content/publish/directives.md
+++ b/content/publish/directives.md
@@ -25,3 +25,7 @@ keywords: []
 ```{myst:directive} template:list
 
 ```
+
+```{myst:directive} bluesky
+
+```

--- a/content/publish/myst-extensions.md
+++ b/content/publish/myst-extensions.md
@@ -46,14 +46,11 @@ Curvenote automatically recognizes and enriches links to Bluesky in your Markdow
 ### Supported URL formats
 
 - **Profile links**: `https://bsky.app/profile/{handle}`
-- **Post links**: `https://bsky.app/profile/{handle}/post/{rkey}`
 
 For example:
 
 ```{myst}
 Check out [Curvenote on Bluesky](https://bsky.app/profile/curvenote.com) for updates.
-
-Or link to a specific post: [this announcement](https://bsky.app/profile/curvenote.com/post/3k2e5y6abc123).
 ```
 
 ### Automatic link text

--- a/content/publish/myst-extensions.md
+++ b/content/publish/myst-extensions.md
@@ -1,0 +1,65 @@
+---
+title: MyST Extensions
+short_title: MyST Extensions
+description: Curvenote extends MyST Markdown with additional directives and link handling for embedding Bluesky content and enriching Bluesky links in your articles.
+---
+
+Curvenote extends [MyST Markdown](./authoring-in-myst.md) with custom directives and link transformers that enhance your content with rich, interactive elements. This page documents the Bluesky integration, which allows you to embed profile cards and create smart links to Bluesky profiles and posts.
+
+## Bluesky Profile Cards
+
+The `{bluesky}` directive embeds an inline Bluesky profile card in your document. Use it to showcase a Bluesky account—for example, when listing authors, contributors, or linking to your project's social presence.
+
+````markdown
+```{bluesky} curvenote.com
+:show-stats: true
+```
+````
+
+The directive accepts a Bluesky handle or DID as its argument. Handles can be provided with or without the `@` prefix (e.g. `opensci.dev` or `@opensci.dev`). You can also use a full DID such as `did:plc:xyz` for accounts that use decentralized identifiers.
+
+### Options
+
+- **show-stats** (boolean, default: `true`): When enabled, the card displays follower, following, and post counts. Set to `false` to show a compact profile card without statistics.
+
+``````{tab-set}
+`````{tab-item} With stats (default)
+````markdown
+```{bluesky} curvenote.com
+:show-stats: true
+```
+````
+`````
+`````{tab-item} Without stats
+````markdown
+```{bluesky} curvenote.com
+:show-stats: false
+```
+````
+`````
+``````
+
+## Bluesky Link Behavior
+
+Curvenote automatically recognizes and enriches links to Bluesky in your Markdown. When you add a link to a Bluesky profile or post, it is transformed so that the frontend can render a rich card or hover preview.
+
+### Supported URL formats
+
+- **Profile links**: `https://bsky.app/profile/{handle}`
+- **Post links**: `https://bsky.app/profile/{handle}/post/{rkey}`
+
+For example:
+
+```{myst}
+Check out [Curvenote on Bluesky](https://bsky.app/profile/curvenote.com) for updates.
+
+Or link to a specific post: [this announcement](https://bsky.app/profile/curvenote.com/post/3k2e5y6abc123).
+```
+
+### Automatic link text
+
+If you use a Bluesky URL as the link destination and leave the link text empty or use the raw URL as the text, Curvenote will automatically replace it with the handle in `@handle` format. This keeps your links readable and consistent.
+
+:::{seealso} Directive reference
+For low-level details on the `{bluesky}` directive options and usage, see the [Directives & Roles](./directives.md#directive-bluesky) reference.
+:::

--- a/content/publish/myst-extensions.md
+++ b/content/publish/myst-extensions.md
@@ -1,7 +1,7 @@
 ---
 title: MyST Extensions
 short_title: MyST Extensions
-description: Curvenote extends MyST Markdown with additional directives and link handling for embedding Bluesky content and enriching Bluesky links in your articles.
+description: Curvenote extends MyST Markdown with additional capabilities such as roles, directives, link transformers and more to bring richer content into your articles.
 ---
 
 Curvenote extends [MyST Markdown](./authoring-in-myst.md) with custom directives and link transformers that enhance your content with rich, interactive elements. This page documents the Bluesky integration, which allows you to embed profile cards and create smart links to Bluesky profiles and posts.

--- a/content/publish/myst.yml
+++ b/content/publish/myst.yml
@@ -59,6 +59,7 @@ project:
     - title: Preparing an article
       children:
         - file: authoring-in-myst.md
+        - file: myst-extensions.md
         - file: metadata-essentials.md
         - file: article-actions.md
         - file: submitting-your-work.md


### PR DESCRIPTION
Add author-facing documentation for the new Blue Sky directive and link behavior, including a new MyST Extensions page and a directive reference entry.

---
Linear Issue: [CN-1710](https://linear.app/curvenote/issue/CN-1710/update-docs)

<p><a href="https://cursor.com/agents/bc-4b5a108a-523b-451f-a3bf-e9a2b4645c4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b5a108a-523b-451f-a3bf-e9a2b4645c4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

